### PR TITLE
Make socials optional during parse

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbl-rs"
-version = "0.2.1"
+version = "0.2.2"
 description = "API Bindings for top.gg / discordbots.org"
 readme = "README.md"
 documentation = "https://docs.rs/dbl-rs"

--- a/src/types.rs
+++ b/src/types.rs
@@ -46,11 +46,11 @@ pub struct DetailedUser {
 /// Social media accounts of the user.
 #[derive(Debug, Deserialize)]
 pub struct Social {
-    pub github: String,
-    pub instagram: String,
-    pub reddit: String,
-    pub twitter: String,
-    pub youtube: String,
+    pub github: Option<String>,
+    pub instagram: Option<String>,
+    pub reddit: Option<String>,
+    pub twitter: Option<String>,
+    pub youtube: Option<String>,
 }
 
 /// Information about a bot.


### PR DESCRIPTION
Hiya!

Thanks for making this! I did run into a small issue when the library tries to grab a `DetailedUser`, the api won't always send these socials, so this marks them as optional.

```
Unable to retrieve user info: error decoding response body: missing field `github` at line 1 column 254
```
