### PR TITLE
Mark Socials As Optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbl-rs"
-version = "0.3.0"
+version = "0.3.1"
 description = "API Bindings for top.gg / discordbots.org"
 readme = "README.md"
 documentation = "https://docs.rs/dbl-rs"

--- a/src/types.rs
+++ b/src/types.rs
@@ -33,7 +33,7 @@ pub struct DetailedUser {
     pub default_avatar: String,
     pub bio: Option<String>,
     pub banner: Option<String>,
-    pub social: Social,
+    pub social: Option<Social>,
     pub color: Option<String>,
     pub supporter: bool,
     pub certified_dev: bool,


### PR DESCRIPTION
It seems they're not always sending the socials - this patch marks it as optional in case we're not given them to prevent decoding failure.

```
WARN  discord_compiler_bot::apis::dbl > Unable to retrieve user info: error decoding response body: missing field `social` at line 1 column 243
```

I'm having déjà vu with #1, I guess now they're not even sending the section if no socials are filled out.